### PR TITLE
Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ include mk/helpers.mk
 # VIVADO stuff
 #################################################################################
 VIVADO_FLAGS=-notrace -mode batch
-BUILD_VIVADO_VERSION=2020.2
+BUILD_VIVADO_VERSION?=2020.2
+BUILD_VIVADO_BASE="/work/Xilinx/Vivado"
 #BUILD_VIVADO_SHELL="/opt/Xilinx/Vivado/"$(BUILD_VIVADO_VERSION)"/settings64.sh"
-BUILD_VIVADO_SHELL="/work/Xilinx/Vivado/"$(BUILD_VIVADO_VERSION)"/settings64.sh"
+BUILD_VIVADO_SHELL=${BUILD_VIVADO_BASE}"/"$(BUILD_VIVADO_VERSION)"/settings64.sh"
 #VIVADO_SETUP=source $(VIVADO_SHELL) && mkdir -p proj && mkdir -p kernel/hw && cd proj
 
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include mk/helpers.mk
 #################################################################################
 VIVADO_FLAGS=-notrace -mode batch
 BUILD_VIVADO_VERSION?=2020.2
-BUILD_VIVADO_BASE="/work/Xilinx/Vivado"
+BUILD_VIVADO_BASE?="/work/Xilinx/Vivado"
 #BUILD_VIVADO_SHELL="/opt/Xilinx/Vivado/"$(BUILD_VIVADO_VERSION)"/settings64.sh"
 BUILD_VIVADO_SHELL=${BUILD_VIVADO_BASE}"/"$(BUILD_VIVADO_VERSION)"/settings64.sh"
 #VIVADO_SETUP=source $(VIVADO_SHELL) && mkdir -p proj && mkdir -p kernel/hw && cd proj

--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ To Build FPGA FW:
   - uHAL (set CACTUS_ROOT and LD_LIBARARY_PATH accordingly)
   - make
 
+### Environment variables
+To override the version and/or location of the Xilinx tools, set the BUILD_VIVADO_VERSION and BUILD_VIVADO_BASE variables. A custom CACTUS location can be set by setting CACTUS_ROOT.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Buildable Groups:
 
 #### FW
 To Build FPGA FW:
-  `make group_revN_FPGA`
+  `make group_revN_FPGA`, e.g., for Cornell CM Rev1 with 7 series zynq, VU7P FPGA: `make Cornell_rev1_p2_VU7p-1-SM_7s`
+
 
   Ouput:
   

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ To Build FPGA FW:
 
 
 ### Dependencies:
-  - Vivado 2018.2 installed in /opt/Xilinx/Vivado/2018.2/
+  - Vivado 2018.2 installed in ${BUILD_VIVADO_BASE}
+  - python2
   - python-yaml
   - python-jinja2
-  - uHAL
+  - uHAL (set CACTUS_ROOT and LD_LIBARARY_PATH accordingly)
   - make
 

--- a/mk/helpers.mk
+++ b/mk/helpers.mk
@@ -6,11 +6,17 @@ SHELL=/bin/bash -o pipefail
 #add path so build can be more generic
 MAKE_PATH := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-OUTPUT_MARKUP= 2>&1 | tee -a ../make_log.txt | ccze -A
+ifeq (, $(shell which ccze 2> /dev/null))
+  CCZE_CMD=
+else
+  CCZE_CMD=| ccze -A
+endif 
+OUTPUT_MARKUP= 2>&1 | tee -a ../make_log.txt ${CCZE_CMD}
 SLACK_MESG ?= echo
 
 all:
 	@echo "Please specify a design to build"
+	echo '${OUTPUT_MARKUP}'
 	@$(MAKE) list 
 
 #################################################################################

--- a/mk/preBuild.mk
+++ b/mk/preBuild.mk
@@ -1,4 +1,4 @@
-CACTUS_ROOT:="/opt/cactus"
+CACTUS_ROOT?="/opt/cactus"
 CACTUS_LD_PATH:=$(CACTUS_ROOT)"/lib/"
 
 #################################################################################


### PR DESCRIPTION
Make build more generic / work at Cornell w/o hacking.

Mostly depends on environment variables / prevents overwriting of makefile settings if environment variables are already set. 

The following environment variables can now be set/changed and will override the defaults in the makefile
```
BUILD_VIVADO_VERSION
BUILD_VIVADO_BASE
CACTUS_ROOT
```
README.md has also been updated.

