### PR TITLE
Feature: add a VU7P -2 speed grade for Cornell CM

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ To Build FPGA FW:
   - make
 
 ### Environment variables
-To override the version and/or location of the Xilinx tools, set the BUILD_VIVADO_VERSION and BUILD_VIVADO_BASE variables. A custom CACTUS location can be set by setting CACTUS_ROOT.
+To override the version and/or location of the Xilinx tools, set the BUILD_VIVADO_VERSION and BUILD_VIVADO_BASE variables. A custom CACTUS location can be set by setting CACTUS_ROOT (you might also need to set PYTHON_ROOT).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To Build FPGA FW:
   - python-yaml
   - python-jinja2
   - uHAL (set CACTUS_ROOT and LD_LIBARARY_PATH accordingly)
+  - device tree compiler (rpm name "dtc")
   - make
 
 ### Environment variables

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/Generate_svf.tcl
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/Generate_svf.tcl
@@ -1,0 +1,37 @@
+#this has to be called from inside an open session
+source ${apollo_root_path}/configs/${build_name}/settings.tcl
+
+#add the device info for the uC
+#set device-info-file ../scripts/CM_uC_dev_info.csv
+
+set SVF_TARGET [format "svf_top%06u" [expr {round(1000000 *rand())}]]
+
+
+
+#derived from walkthrough https://blog.xjtag.com/2016/07/creating-svf-files-using-xilinx-vivado/
+open_hw
+if { [string length [get_hw_targets -quiet -regexp .*/${SVF_TARGET}] ]  } {
+  delete_hw_target -quiet [get_hw_targets -regexp .*/${SVF_TARGET}]
+}
+create_hw_target ${SVF_TARGET}
+close_hw_target
+open_hw_target [get_hw_targets -regexp .*/${SVF_TARGET}]
+
+#add the uC to the chain
+#create_hw_device -idcode 4BA00477
+
+# add the kintex to the chain
+# create_hw_device -part xcku15p-ffva1760-2-e
+
+#add the virtex to the chain
+set DEVICE [create_hw_device -part ${FPGA_part}]
+set_property PROGRAM.FILE ${apollo_root_path}/bit/top_${build_name}.bit $DEVICE
+set_param xicom.config_chunk_size 0
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+
+program_hw_devices -force -svf_file ${apollo_root_path}/bit/top_${build_name}.svf ${DEVICE}
+
+write_cfgmem -force -loadbit "up 0 ${apollo_root_path}/bit/top_${build_name}.bit" -format mcs -size 128 -file "${apollo_root_path}/bit/top_${build_name}.mcs"
+
+delete_hw_target -quiet [get_hw_targets -regexp .*/${SVF_TARGET}]

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/autogen
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/autogen
@@ -1,0 +1,1 @@
+../Cornell_rev1_p2_VU7p-1-SM_USP/autogen/

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/files.tcl
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/files.tcl
@@ -1,0 +1,1 @@
+../Cornell_rev1_p2_VU7p-1-SM_USP/files.tcl

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/settings.tcl
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/settings.tcl
@@ -1,0 +1,8 @@
+
+#set the FPGA part number
+set FPGA_part xcvu7p-flvb2104-2-e
+
+set top top
+
+set outputDir ./
+

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/slaves.yaml
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/slaves.yaml
@@ -1,0 +1,1 @@
+../Cornell_rev1_p2_VU7p-1-SM_7s/slaves.yaml

--- a/configs/Cornell_rev1_p2_VU7p-2-SM_7s/src
+++ b/configs/Cornell_rev1_p2_VU7p-2-SM_7s/src
@@ -1,0 +1,1 @@
+../Cornell_rev1_p2_VU7p-1-SM_USP/src/


### PR DESCRIPTION
Add a new config for the Rev1 CM from Cornell with a -2 VU7P and 7 series Zynq.

The config is mostly the same as the -1 with two changes
- new speed grade for the FPGA
- svf generation does not have the KU in the chain (since the two boards with -2 FPGAs do not have KU on them.)
Soft links to common files otherwise.

Also update the README to the requirement for the device tree compiler (rpm name `dtc`)

On my machine at Cornell the build fails due to issues with the block diagram creation (repository BU_BUILT.git) ; the changes there are 
- fix issue with version compare since newest 2020.2 has subversions (2020.2.2)
- remove some startgroup/endgroup calls in the TCL script that were causing the build to fail 
Ugly diff is attached.
[diff.txt](https://github.com/apollo-lhc/CM_FPGA_FW/files/6858948/diff.txt)
