### PR TITLE
updates to allow LocalClocking (and other xci) to be generated from TCL

### DIFF
--- a/configs/Cornell_rev1_p2_VU7p-1-SM_USP/files.tcl
+++ b/configs/Cornell_rev1_p2_VU7p-1-SM_USP/files.tcl
@@ -32,5 +32,5 @@ set xdc_files "\
     "	    
 
 set xci_files "\
-    	      cores/Local_Clocking/Local_Clocking.xci \
+    	      cores/Local_Clocking/Local_Clocking.tcl \
     	      "

--- a/cores/Local_Clocking/Local_Clocking.tcl
+++ b/cores/Local_Clocking/Local_Clocking.tcl
@@ -1,0 +1,57 @@
+set name Local_Clocking
+
+set output_path ${apollo_root_path}/cores
+
+file mkdir ${output_path}
+
+if { [file exists ${output_path}/${name}/${name}.xci] && ([file mtime ${output_path}/${name}/${name}.xci] > [file mtime ${output_path}/${name}/${name}.tcl])} {
+    set filename "${output_path}/${name}/${name}.xci"
+    set ip_name [file rootname [file tail $filename]]
+    #normal xci file
+    read_ip $filename
+    set isLocked [get_property IS_LOCKED [get_ips $ip_name]]
+    puts "IP $ip_name : locked = $isLocked"
+    set upgrade  [get_property UPGRADE_VERSIONS [get_ips $ip_name]]
+    if {$isLocked && $upgrade != ""} {
+	puts "Upgrading IP"
+	upgrade_ip [get_ips $ip_name]
+    }    
+} else {
+    file delete -force ${apollo_root_path}/cores/${name}/${name}.xci
+
+    #create IP
+    create_ip -vlnv [get_ipdefs -filter {NAME == clk_wiz}] -module_name ${name} -dir ${output_path}/${name}
+    set_property -dict [list \
+			    CONFIG.PRIM_SOURCE {Differential_clock_capable_pin} \
+			    CONFIG.PRIM_IN_FREQ {200} \
+			    CONFIG.CLKOUT2_USED {true} \
+			    CONFIG.CLKOUT3_USED {true} \
+			    CONFIG.CLK_OUT1_PORT {clk_200} \
+			    CONFIG.CLK_OUT2_PORT {clk_50} \
+			    CONFIG.CLK_OUT3_PORT {clk_axi} \
+			    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {200} \
+			    CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {50} \
+			    CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {50} \
+			    CONFIG.CLKOUT1_MATCHED_ROUTING {false} \
+			    CONFIG.CLKOUT2_MATCHED_ROUTING {false} \
+			    CONFIG.CLKOUT3_MATCHED_ROUTING {false} \
+			    CONFIG.CLKIN1_JITTER_PS {50.0} \
+			    CONFIG.MMCM_CLKFBOUT_MULT_F {6.000} \
+			    CONFIG.MMCM_CLKIN1_PERIOD {5.000} \
+			    CONFIG.MMCM_CLKIN2_PERIOD {10.0} \
+			    CONFIG.MMCM_CLKOUT0_DIVIDE_F {6.000} \
+			    CONFIG.MMCM_CLKOUT1_DIVIDE {24} \
+			    CONFIG.MMCM_CLKOUT2_DIVIDE {24} \
+			    CONFIG.NUM_OUT_CLKS {3} \
+			    CONFIG.CLKOUT1_JITTER {92.799} \
+			    CONFIG.CLKOUT1_PHASE_ERROR {82.655} \
+			    CONFIG.CLKOUT2_JITTER {121.478} \
+			    CONFIG.CLKOUT2_PHASE_ERROR {82.655} \
+			    CONFIG.CLKOUT3_JITTER {121.478} \
+			    CONFIG.CLKOUT3_PHASE_ERROR {82.655}
+		       ] [ get_ips ${name} ]
+
+
+}
+
+

--- a/scripts/Setup.tcl
+++ b/scripts/Setup.tcl
@@ -59,15 +59,18 @@ for {set j 0} {$j < [llength $xci_files ] } {incr j} {
     set filename "${apollo_root_path}/[lindex $xci_files $j]"
     set ip_name [file rootname [file tail $filename]]
     puts "Adding $filename"    
-    read_ip $filename
-    set isLocked [get_property IS_LOCKED [get_ips $ip_name]]
-    puts "IP $ip_name : locked = $isLocked"
-    set upgrade  [get_property UPGRADE_VERSIONS [get_ips $ip_name]]
-    if {$isLocked && $upgrade != ""} {
-	puts "Upgrading IP"
-	upgrade_ip [get_ips $ip_name]}
+    if { [file extension ${filename} ] == ".tcl" } {
+	source ${filename}
+    } else {
+	read_ip $filename
+	set isLocked [get_property IS_LOCKED [get_ips $ip_name]]
+	puts "IP $ip_name : locked = $isLocked"
+	set upgrade  [get_property UPGRADE_VERSIONS [get_ips $ip_name]]
+	if {$isLocked && $upgrade != ""} {
+	    puts "Upgrading IP"
+	    upgrade_ip [get_ips $ip_name]}
 
-
+    }
     puts "Generating target all on $ip_name"
     generate_target all [get_ips $ip_name]  
     puts "Running synth on $ip_name"


### PR DESCRIPTION
Modeling after the SM repo, add a way to generate xci files from TCL. This will allow changes in version hopefully.

	modified:   configs/Cornell_rev1_p2_VU7p-1-SM_USP/files.tcl
	new file:   cores/Local_Clocking/Local_Clocking.tcl
	modified:   scripts/Setup.tcl

@dgastler not sure if I should delete `Local_Clocking.xci`; right now I did not. 
This is independent of #26 
Note this also requires the attached diff in the bd directory (which is a git submodule) to build on my machines at Cornell. [diff.txt](https://github.com/apollo-lhc/CM_FPGA_FW/files/6919837/diff.txt)
